### PR TITLE
Fix broken link to Settings documentation

### DIFF
--- a/app/html/docs/usage.html
+++ b/app/html/docs/usage.html
@@ -48,7 +48,7 @@
     <p>
         By default Package Control checks for new versions on startup. This
         setting, plus the list of channels and repositories are managed through
-        the <a href="/settings">Settings</a>.
+        the <a href="/docs/settings">Settings</a>.
     </p>
 </section>
 


### PR DESCRIPTION
On https://sublime.wbond.net/docs/usage, there is a link that should be https://sublime.wbond.net/docs/settings, not https://sublime.wbond.net/settings.
