### PR TITLE
preventDefault on ctrl+shift+p, and tabindex=0 to get the focus first

### DIFF
--- a/app/js/header.coffee
+++ b/app/js/header.coffee
@@ -131,6 +131,7 @@ class App.Header extends Backbone.View
     # Allow users to use ctrl+shift+p or cmd+shift+p to focus search
     window.keymaster('command+shift+p, ctrl+shift+p', (e) =>
       @$search.focus()
+      e.preventDefault()
     )
 
     window.keymaster('enter', 'search', (e) =>

--- a/app/templates/partials/header.handlebars
+++ b/app/templates/partials/header.handlebars
@@ -125,7 +125,7 @@
                     </div>
 
                     <form action="/search" method="get">
-                        <input id="search" type="text" placeholder="Search" name="terms" value="{{terms}}">
+                        <input id="search" type="text" placeholder="Search" name="terms" value="{{terms}}" tabindex="0">
                         <span class="help">
                             <span class="keys">ctrl+shift+p</span>
                             <span class="terms">


### PR DESCRIPTION
Hello!

I'm using package control, and it's really great, thank you so much for creating and maintaining it!

But, there's a really simple problem, here's the issue #28. So I just made 2 changes:

1. add `e.preventDefault()`
2. set the `tabindex` to `0`

**I haven't test it, because I can't, but it should work**

Have a nice day,
Matt