### PR TITLE
set focus to search field

### DIFF
--- a/app/templates/partials/header.handlebars
+++ b/app/templates/partials/header.handlebars
@@ -125,7 +125,7 @@
                     </div>
 
                     <form action="/search" method="get">
-                        <input id="search" type="text" placeholder="Search" name="terms" value="{{terms}}">
+                        <input id="search" type="text" placeholder="Search" name="terms" value="{{terms}}" autofocus>
                         <span class="help">
                             <span class="keys">ctrl+shift+p</span>
                             <span class="terms">


### PR DESCRIPTION
It would be nice to be able to search immediately when opening packagecontrol.io.
Feel free to reject of course.