### PR TITLE
Replace "OS X" with "macOS" in user-visible site text

### DIFF
--- a/app/html/docs/settings.html
+++ b/app/html/docs/settings.html
@@ -256,7 +256,7 @@
             <p>
                 This setting allows Windows users to bypass wininet and use
                 urllib instead if they machine or network presents trouble to
-                wininet. Some OS X and Linux users have also reported better
+                wininet. Some macOS and Linux users have also reported better
                 luck with certain proxies using curl or wget instead of urllib.
             </p>
             <p>

--- a/app/html/docs/submitting_a_package.html
+++ b/app/html/docs/submitting_a_package.html
@@ -233,7 +233,7 @@
 		<ul>
 			<li>
 				<p>
-					<em>Package that only works on OS X and Linux</em>
+					<em>Package that only works on macOS and Linux</em>
 				</p>
 				<pre>{
 	"name": "Alignment",

--- a/app/html/docs/syncing.html
+++ b/app/html/docs/syncing.html
@@ -66,7 +66,7 @@
 
 <ul>
     <li><a href="#dropbox-windows">Windows instructions</a></li>
-    <li><a href="#dropbox-osx">OS X instructions</a></li>
+    <li><a href="#dropbox-osx">macOS instructions</a></li>
     <li><a href="#dropbox-linux">Linux instructions</a></li>
 </ul>
 
@@ -126,7 +126,7 @@ cmd /c mklink /D User $env:userprofile\Dropbox\Sublime\User
 </div>
 
 
-<h3 id="dropbox-osx">OS X</h3>
+<h3 id="dropbox-osx">macOS</h3>
 
 <p>
     If your Dropbox folder is not in the default location, you'll need to

--- a/app/html/docs/usage.html
+++ b/app/html/docs/usage.html
@@ -10,7 +10,7 @@
         Package Control is driven by the Command Palette. To open the palette,
         press <kbd>ctrl<em>+</em>shift<em>+</em>p</kbd> (Win, Linux) or
         <kbd>cmd<em>+</em>shift<em>+</em>p</kbd>
-        (OS X). All Package Control commands begin with <tt>Package
+        (macOS). All Package Control commands begin with <tt>Package
         Control:</tt>, so start by typing <kbd>Package</kbd>.
     </p>
     <p>

--- a/setup/osx.md
+++ b/setup/osx.md
@@ -1,4 +1,4 @@
-# OS X System Setup
+# macOS System Setup
 
 These instructions assume you have homebrew installed on your machine and that
 you have the XCode command line tools installed.


### PR DESCRIPTION
Apple renamed their OS from "OS X" to "macOS" a few years back. What do you think about updating the user-visible site text to reflect this?