### PR TITLE
Typo fixes

### DIFF
--- a/app/html/about.html
+++ b/app/html/about.html
@@ -14,7 +14,7 @@
     <p>
         Package Control grew out of the need for a way to easily distribute
         updates to my first package, <a href="/packages/SFTP">SFTP</a>. Today
-        this server delivers around 5TB of compressed json data a month and
+        this server delivers around 5TB of compressed JSON data a month and
         has seen over 2.7 million unique clients connect -
         <a href="/stats">full stats</a>.
     </p>

--- a/app/html/docs/channels_and_repositories.html
+++ b/app/html/docs/channels_and_repositories.html
@@ -25,7 +25,7 @@
 	<a href="https://github.com/wbond/package_control_channel/tree/master/repository">single, centralized repository</a>
 	for developers who are using GitHub or BitBucket tag-based releases. This
 	way a package only ever needs to be added to the repository once and almost
-	all futher updates to the package can be performed via the GitHub or
+	all further updates to the package can be performed via the GitHub or
 	BitBucket user interfaces.
 </p>
 
@@ -41,6 +41,6 @@
 <p>
 	Once the file has been upgraded, most packages can then be migrated into
 	the <a href="https://github.com/wbond/package_control_channel/tree/master/repository">default repository</a>.
-	Most uses of custom repository JSON files was due to deficiencies with
+	Most uses of custom repository JSON files were due to deficiencies with
 	<tt>schema_version</tt> <tt>1.2</tt> and <tt>2.0</tt>.
 </p>

--- a/app/html/docs/creating_package_files.html
+++ b/app/html/docs/creating_package_files.html
@@ -30,7 +30,7 @@
 
 <p>
 	The <a href="/docs/settings#setting-package_profiles"><tt>package_profiles</tt></a>
-	setting allows created other named profiles that can override each of the
+	setting allows creating other named profiles that can override each of the
 	settings listed above. By default, a single custom profile is included:
 	<tt>Binaries Only</tt>. Copy the settings from <span class="menu">Preferences
 	<em>&gt;</em> Package Settings <em>&gt;</em> Package Control <em>&gt;</em>
@@ -43,7 +43,7 @@
 
 <p>
 	Running the <em>Create Package</em> command will prompt you to select a
-	pakage to create the package file for. Next, it will ask you to choose what
+	package to create the package file for. Next, it will ask you to choose what
 	package profile you would like to use. Package Control will then create
 	a <tt>.sublime-package</tt> file, add the package files to it and place it
 	in the <tt>package_destination</tt>.
@@ -54,9 +54,9 @@
 <p>
 	With Sublime Text 2, all python files are compiled into <tt>.pyc</tt> files
 	by default by Sublime Text itself. This allows you to choose if you want to
-	ship a binary only-package. Python 3 in Sublime Text 3 changes how Python
+	ship a binary-only package. Python 3 in Sublime Text 3 changes how Python
 	scripts are compiled, storing them all in a <tt>__pycache__/</tt> folder,
-	which doesn't work if you are trying to ship a binary only package.
+	which doesn’t work if you are trying to ship a binary only package.
 </p>
 
 <p>

--- a/app/html/docs/customizing_packages.html
+++ b/app/html/docs/customizing_packages.html
@@ -44,7 +44,7 @@
 <h2 id="Editing_Unpacked_Files">Editing Unpacked Files</h2>
 
 <p>
-	Editing an unpacked package‘s files is not a good idea unless you‘ve cloned
+	Editing an unpacked package’s files is not a good idea unless you’ve cloned
 	the package via Git/Hg. This is because, by default, Package Control will
 	automatically upgrade packages to the newest version. This will cause any
 	edits to files to be overwritten. If you experience this, you may
@@ -86,7 +86,7 @@
 
 <p>
 	For complete customization of a package, it will likely be necessary to
-	using a version control program, such as Git or Hg to clone a copy of
+	use a version control program, such as Git or Hg, to clone a copy of
 	the original package repository into the <tt>Packages/</tt> folder.
 </p>
 
@@ -98,7 +98,7 @@
 </p>
 
 <p>
-	If you‘ve cloned it from your own fork of the
+	If you’ve cloned it from your own fork of the
 	repository, no settings need to be changed. If you clone it from the
 	original repository, you will likely want to set the
 	<a href="/docs/settings#setting-ignore_vcs_packages">ignore_vcs_packages</a>

--- a/app/html/docs/dependencies.html
+++ b/app/html/docs/dependencies.html
@@ -14,7 +14,7 @@
 
 <p>
 	Similar to packages, dependencies are distributed through a repository.
-	Dependencies are always fully extracted to the user‘s <tt>Packages/</tt>
+	Dependencies are always fully extracted to the user’s <tt>Packages/</tt>
 	folder, using their name. Thus, dependency and package names exist in a
 	single namespace. This means you can not have a dependency with the same
 	name as a package.
@@ -31,8 +31,8 @@
 
 <p>
 	The generated python file looks for predefined subfolder names in the
-	dependency folder, based on the user‘s machine. Each matching subfolder that
-	is found will be added to Python‘s <tt>sys.path</tt> list, which is used to
+	dependency folder, based on the user’s machine. Each matching subfolder that
+	is found will be added to Python’s <tt>sys.path</tt> list, which is used to
 	load modules.
 </p>
 
@@ -40,7 +40,7 @@
 	The predefined subfolder names are in the formats:
 	<tt>st{st_version}_{os}_{arch}</tt>, <tt>st{st_version}_{os}</tt>,
 	<tt>st{st_version}</tt> and <tt>all</tt>. For example, with Sublime Text 3
-	on a 64bit Linux machine the following subfolders will be checked:
+	on a 64-bit Linux machine the following subfolders will be checked:
 </p>
 
 <ol>

--- a/app/html/docs/events.html
+++ b/app/html/docs/events.html
@@ -38,7 +38,7 @@
 	The events API is a layer of extra information that allows code being run
 	inside of the Sublime Text 3 <tt>plugin_loaded()</tt> and
 	<tt>plugin_unloaded()</tt> handlers. These handlers are automatically
-	executed whenever a package is install/enabled or removed/disabled,
+	executed whenever a package is installed/enabled or removed/disabled,
 	respectively.
 </p>
 

--- a/app/html/docs/issues.html
+++ b/app/html/docs/issues.html
@@ -6,7 +6,7 @@
 <p>
     Are you having trouble using Package Control? Before opening an issue,
     please take the time to perform the following few steps. Properly following
-    directions will improve the likelyhood of your issue be quickly resolved.
+    directions will improve the likelihood of your issue being quickly resolved.
 </p>
 
 <ol>

--- a/app/html/docs/messaging.html
+++ b/app/html/docs/messaging.html
@@ -4,7 +4,7 @@
 <h1>Messaging</h1>
 
 <p>
-	If you‘ve used many package with Sublime Text and Package Control, you may
+	If you’ve used many packages with Sublime Text and Package Control, you may
 	have noticed situations where Package Control shows messages. Currently it
 	is possible to show users a message when the package is installed, or after
 	upgrades.
@@ -13,7 +13,7 @@
 	Messaging is controlled by a file named <tt>messages.json</tt> in the root
 	of the package. The
 	<em><a href="https://raw.githubusercontent.com/wbond/package_control/master/example-messages.json">example-messages.json</a></em>
-	file shows the proper structure of the json. Each value will be a file path
+	file shows the proper structure of the JSON. Each value will be a file path
 	that is relative to the package root. Each key will either be the
 	string <tt>install</tt> or a version number.
 </p>

--- a/app/html/docs/settings.html
+++ b/app/html/docs/settings.html
@@ -71,7 +71,7 @@
         <dt id="setting-install_prereleases">install_prereleases</dt>
         <dd>
             A list of packages to install pre-release versions for. Versions
-            under 1.0.0 are not considered pre-release, only those using the
+            under 1.0.0 are not considered pre-release; only those using the
             SemVer <tt>-prerelease</tt> suffixes will be ignored if the package
             is not in this list.
             <div class="default">
@@ -80,7 +80,7 @@
         </dd>
         <dt id="setting-package_name_map">package_name_map</dt>
         <dd>
-            This helps solve naming issues where a repository it not named the
+            This helps solve naming issues where a repository is not named the
             same as the package should be. This is primarily only useful for
             GitHub and BitBucket repositories. This mapping will override the
             mapping that is retrieved from the repository channels.
@@ -200,7 +200,7 @@
         </dd>
         <dt id="setting-git_binary">git_binary</dt>
         <dd>
-            Custom path(s) to <tt>git</tt> binary for when it can't be
+            Custom path(s) to <tt>git</tt> binary for when it can’t be
             automatically found on the system and a package includes a
             <tt>.git</tt> metadata directory. Supports more than one path to
             allow users to sync settings across operating systems.
@@ -218,7 +218,7 @@
         </dd>
         <dt id="setting-hg_binary">hg_binary</dt>
         <dd>
-            Custom path(s) to <tt>hg</tt> binary for when it can't be
+            Custom path(s) to <tt>hg</tt> binary for when it can’t be
             automatically found on the system and a package includes a
             <tt>.hg</tt> metadata directory. Supports more than one path to
             allow users to sync settings across operating systems.
@@ -255,7 +255,7 @@
             </p>
             <p>
                 This setting allows Windows users to bypass wininet and use
-                urllib instead if they machine or network presents trouble to
+                urllib instead if their machine or network presents trouble to
                 wininet. Some OS X and Linux users have also reported better
                 luck with certain proxies using curl or wget instead of urllib.
             </p>
@@ -327,7 +327,7 @@
                 <li><tt>"package_destination"</tt></li>
             </ul>
             <p>
-                If a profile does not include one of those three setting, it will fall
+                If a profile does not include one of those three settings, it will fall
                 back to the top-level settings.
             </p>
             <div class="default">
@@ -350,7 +350,7 @@
         </dd>
         <dt id="setting-enable_tests">enable_tests</dt>
         <dd>
-            Enable the ability to run the tests - this is only for development.
+            Enable the ability to run the tests – this is only for development.
             <div class="default">
                 <em>Default</em> <tt>false</tt>
             </div>

--- a/app/html/docs/submitting_a_package.html
+++ b/app/html/docs/submitting_a_package.html
@@ -41,7 +41,7 @@
 		material, but omit it the package list, e.g. Sublime SFTP.
 	</li>
 	<li>
-		<b>Don‘t use a name too similar to another.</b> We don‘t
+		<b>Don’t use a name too similar to another.</b> We don’t
 		want <tt>SublimeTodo</tt> and <tt>Sublime T0d0</tt>.
 	</li>
 	<li>
@@ -92,10 +92,10 @@
 	</li>
 	<li>
 		<b>Host <tt>.sublime-package</tt> files and a <tt>packages.json</tt> on
-		a web server with SSL.</b> For each release you‘ll need to create and upload
+		a web server with SSL.</b> For each release you’ll need to create and upload
 		a new package file and update the <tt>packages.json</tt> information.
 		Hosting of the files must be done on a secure server to help ensure the
-		security of users‘ machines. Unsecure URLs could lead to malicious code
+		security of users’ machines. Unsecure URLs could lead to malicious code
 		being loaded and run.
 		<em>This is rarely used – see
 		<a href="https://raw.githubusercontent.com/wbond/package_control/master/example-repository.json">example-repository.json</a>
@@ -145,7 +145,7 @@
 		valid characters in a file name. Be sure file names do not contain
 		characters including: <tt>&lt;</tt>, <tt>&gt;</tt>, <tt>:</tt>,
 		<tt>&quot;</tt>, <tt>/</tt>, <tt>\</tt>, <tt>|</tt>, <tt>?</tt> and
-		<tt>*</tt>. Non-ASCII characters may present troublesome when developing
+		<tt>*</tt>. Non-ASCII characters may present trouble when developing
 		cross-platform packages.
 	</li>
 	<li>

--- a/app/html/docs/troubleshooting.html
+++ b/app/html/docs/troubleshooting.html
@@ -116,7 +116,7 @@
 	If purging and reinstalling did not help resolve an issue, the next step
 	is to enable the debug log. The debug log contains extensive information
 	about what Package Control is doing behind the scenes, and can help to
-	diagnose why it isn't working properly.
+	diagnose why it isn’t working properly.
 </p>
 
 <ol>


### PR DESCRIPTION
Just some typo fixes to the user-visible HTML pages.

Some of these lines with apostrophes may look like they have no changes. This is because the existing curly apostrophes were backward, and this PR changes them to the correct apostrophes; the difference can be hard to see with some fonts.