### PR TITLE
Add OpenSearch support

### DIFF
--- a/app/controllers/__init__.py
+++ b/app/controllers/__init__.py
@@ -23,6 +23,7 @@ from .labels import labels_controller
 from .messaging import messaging_controller
 from .new import new_controller
 from .news import news_controller
+from .opensearch_suggestions import opensearch_suggestions_controller
 from .package import package_controller
 from .packages import packages_controller
 from .popular import popular_controller

--- a/app/controllers/opensearch_suggestions.py
+++ b/app/controllers/opensearch_suggestions.py
@@ -1,0 +1,20 @@
+import json
+
+from bottle import route, response
+
+from ..models import package
+
+
+@route('/opensearch_suggestions', name='opensearch_suggestions_blank')
+@route('/opensearch_suggestions/<terms:re:(.*)>', name='opensearch_suggestions')
+def opensearch_suggestions_controller(terms=''):
+    # TODO: Optimize this call, since we're requesting a lot of stuff we don't need
+    results = package.find.search(terms, 'relevance', 1, 10)
+
+    # Convert data to match suggestion extension format
+    # https://github.com/dewitt/opensearch/blob/master/mediawiki/Specifications/OpenSearch/Extensions/Suggestions/1.1/Draft%201.wiki
+    data = [terms, [package['name'] for package in results['packages']]]
+
+    # Manually convert to JSON, since the response is a list and not a dict
+    response.content_type = 'application/x-suggestions+json'
+    return json.dumps(data)

--- a/app/html/five_hundred.html
+++ b/app/html/five_hundred.html
@@ -7,6 +7,7 @@
         <link rel="stylesheet" href="/css/app.css" type="text/css" media="all" />
         <link href="//netdna.bootstrapcdn.com/font-awesome/3.2.1/css/font-awesome.css" rel="stylesheet">
         <meta name="viewport" content="width=380" id="meta-viewport" />
+        <link rel="search" type="application/opensearchdescription+xml" href="/opensearch.xml" title="Package Control" />
         <script>
         window.onload = function() {
             if (screen.width < 740) { return; } // Make phones use 380

--- a/app/templates/partials/header.handlebars
+++ b/app/templates/partials/header.handlebars
@@ -84,6 +84,7 @@
         <link rel="stylesheet" href="/css/app.css?v={{__version__}}" type="text/css" media="all" />
         <link href="//netdna.bootstrapcdn.com/font-awesome/3.2.1/css/font-awesome.css" rel="stylesheet">
         <meta name="viewport" content="width=380" id="meta-viewport" />
+        <link rel="search" type="application/opensearchdescription+xml" href="/opensearch.xml" title="Package Control" />
         <script>
         window.onload = function() {
             if (screen.width < 740) { return; } /* Make phones use 380 */

--- a/dev.py
+++ b/dev.py
@@ -37,6 +37,11 @@ def server_html(filename):
     return add_version(response)
 
 
+@bottle.route('/opensearch.xml')
+def server_opensearch():
+    return bottle.static_file('opensearch.xml', root=public_root, mimetype='application/opensearchdescription+xml')
+
+
 @bottle.route('/favicon.ico')
 def server_fav():
     return bottle.static_file('favicon.ico', root=public_root)

--- a/public/opensearch.xml
+++ b/public/opensearch.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/" xmlns:moz="http://www.mozilla.org/2006/browser/search/">
+<ShortName>Package Control</ShortName>
+<Description>The Sublime Text package manager that makes it exceedingly simple to find, install and keep packages up-to-date</Description>
+<Url type="text/html" method="GET" template="https://packagecontrol.io/search/{searchTerms}" />
+<Url type="application/opensearchdescription+xml" rel="self" template="https://packagecontrol.io/opensearch.xml" />
+<Language>en-US</Language>
+<moz:SearchForm>https://packagecontrol.io/search</moz:SearchForm>
+</OpenSearchDescription>

--- a/public/opensearch.xml
+++ b/public/opensearch.xml
@@ -4,6 +4,7 @@
 <Description>The Sublime Text package manager that makes it exceedingly simple to find, install and keep packages up-to-date</Description>
 <Url type="text/html" method="GET" template="https://packagecontrol.io/search/{searchTerms}" />
 <Url type="application/opensearchdescription+xml" rel="self" template="https://packagecontrol.io/opensearch.xml" />
+<Url type="application/x-suggestions+json" method="get" template="https://packagecontrol.io/opensearch_suggestions/{searchTerms}.json" />
 <Language>en-US</Language>
 <moz:SearchForm>https://packagecontrol.io/search</moz:SearchForm>
 </OpenSearchDescription>

--- a/public/opensearch.xml
+++ b/public/opensearch.xml
@@ -5,6 +5,7 @@
 <Url type="text/html" method="GET" template="https://packagecontrol.io/search/{searchTerms}" />
 <Url type="application/opensearchdescription+xml" rel="self" template="https://packagecontrol.io/opensearch.xml" />
 <Url type="application/x-suggestions+json" method="get" template="https://packagecontrol.io/opensearch_suggestions/{searchTerms}.json" />
+<Image height="64" width="64" type="image/x-icon">https://packagecontrol.io/favicon.ico</Image>
 <Language>en-US</Language>
 <moz:SearchForm>https://packagecontrol.io/search</moz:SearchForm>
 </OpenSearchDescription>

--- a/servers.sh
+++ b/servers.sh
@@ -156,6 +156,13 @@ if [[ $TASK == "start" ]]; then
                 try_files  \$uri  @site;
             }
 
+            # Override OpenSearch content type
+            location /opensearch.xml {
+                types {
+                    application/opensearchdescription+xml xml;
+                }
+            }
+
             location @site {
                 access_by_lua_file  "$PROJ_DIR/realtime/record_web.lua";
                 proxy_pass http://localhost:9000;


### PR DESCRIPTION
Adds OpenSearch description document, auto discovery of said document and a suggestion/autocompletion service.

Allows Firefox users to add Package Control as a search engine, and allows Chromium users, after they've visited the main page, to search via. packagecontrol.io and see suggestions.

I'm not sure I did the NGINX part correctly, please verify that!

See [the specifications](https://github.com/dewitt/opensearch) and [MDN](https://developer.mozilla.org/en-US/docs/Web/OpenSearch) for more info.