### PR TITLE
Suggest adding a .gitattributes file

### DIFF
--- a/app/html/docs/submitting_a_package.html
+++ b/app/html/docs/submitting_a_package.html
@@ -154,6 +154,15 @@
 		of your repository will prevent Package Control from keeping your
 		package packed as a <tt>.sublime-package</tt> file in ST3.
 	</li>
+	<li>
+		<b>Add a
+		<a href="https://www.git-scm.com/docs/gitattributes"><tt>.gitattributes</tt></a>
+		file.</b>  If your repository includes any files that are not necessary
+		for end-users, such as tests, they can be omitted from the package by
+		setting the <tt>export-ignore</tt> attribute.  You can use
+		<a href="https://git-scm.com/docs/git-archive"><tt>git archive</tt></a>
+		to test your attributes.
+	</li>
 </ol>
 
 <h2 id="Step_6">6. Add Your Repository to the Default Channel</h2>


### PR DESCRIPTION
While working on wbond/package_control_channel#8090, I was surprised
to learn that there is a way to exclude files from the final package.