### PR TITLE
Fix typo in docs

### DIFF
--- a/app/html/docs/customizing_packages.html
+++ b/app/html/docs/customizing_packages.html
@@ -16,7 +16,7 @@
 <p>
 	Sublime Text 3 offers the most options for overriding a package. By default,
 	packages will be installed by placing a <tt>.sublime-package</tt> file
-	in the <tt>Install Packages/</tt> folder. Then users may override individual
+	in the <tt>Installed Packages/</tt> folder. Then users may override individual
 	files in the package by creating a folder <tt>Packages/{Package Name}/</tt>
 	and placing edited files in there.
 </p>


### PR DESCRIPTION
Fixes an incorrect folder name in the "Customizing Packages" section of the docs