### PR TITLE
Fix #152 Show ST4 badges

### DIFF
--- a/app/css/messaging.scss
+++ b/app/css/messaging.scss
@@ -144,6 +144,10 @@ span.versions {
 		background-color: $green;
 		color: $white;
 	}
+	&.latest {
+		background-color: $green;
+		color: $white;
+	}
 }
 
 span.platforms,

--- a/app/templates/package.handlebars
+++ b/app/templates/package.handlebars
@@ -6,7 +6,6 @@
 <div class="meta">
     {{>package_author}}
     {{>package_compat}}
-    {{#contains st_versions 2 3 4}}<span class="versions all" title="Works with all versions of Sublime Text">ALL</span>{{/contains}}
     {{>package_badges}}
 </div>
 

--- a/app/templates/partials/package_compat.handlebars
+++ b/app/templates/partials/package_compat.handlebars
@@ -1,11 +1,12 @@
 {{#omits platforms "osx" "linux" "windows"}}
     {{!-- There are no releases, most likely due to a crawling issue --}}
 {{else}}
-    {{#eq st_versions 4}}<span class="versions only" title="Only works with Sublime Text 4">ST4</span>{{/eq}}
+    {{#eq st_versions 2 3 4}}<span class="versions all" title="Works with all versions of Sublime Text">ALL</span>{{/eq}}
+    {{#eq st_versions 4}}<span class="versions latest" title="Only works with Sublime Text 4">ST4</span>{{/eq}}
     {{#eq st_versions 3}}<span class="versions only" title="Only works with Sublime Text 3">ST3</span>{{/eq}}
     {{#eq st_versions 2}}<span class="versions only" title="Only works with Sublime Text 2">ST2</span>{{/eq}}
-    {{#eq st_versions 3 4}}<span class="versions only" title="Works with Sublime Text 3+">ST3</span>{{/eq}}
-    {{#eq st_versions 2 3}}<span class="versions only" title="Works with Sublime Text 2 and 3">ST2/ST3</span>{{/eq}}
+    {{#eq st_versions 3 4}}<span class="versions only" title="Works with Sublime Text 3">ST3</span><span class="versions latest" title="Works with Sublime Text 4">ST4</span>{{/eq}}
+    {{#eq st_versions 2 3}}<span class="versions only" title="Works with Sublime Text 2">ST2</span><span class="versions only" title="Works with Sublime Text 3">ST3</span>{{/eq}}
 
     {{#omits platforms "osx" "linux"}}<span class="platforms windows" title="Only available on Windows">Win</span>{{/omits}}
     {{#omits platforms "windows" "linux"}}<span class="platforms osx" title="Only available on Mac">Mac</span>{{/omits}}


### PR DESCRIPTION
- Show ST4 badges for packages that support ST4.
  Previously no badge was shown for packages that support ST4. This fixes #152

- Make ST4 badges green like the ALL badge.
  Previously only the ALL badge was green, but I think the latest version should also be green.

- Show ALL badge on package list.
  Previously no badge was shown on the listing page for packages that support all versions.

Fix #152

**Q. Do I need to include the app.css and app.js files?**

---


**Listing before**

![listing-before](https://github.com/wbond/packagecontrol.io/assets/44148/1f05455f-9c4f-488f-ba78-a571330a95a5)

**Listing after**

![listing](https://github.com/wbond/packagecontrol.io/assets/44148/7cbd8ef4-47be-4102-b91f-b8e22beccfbe)


**Package page before**

![package-before](https://github.com/wbond/packagecontrol.io/assets/44148/172cf5ce-dc08-43a0-83e9-4cc214a85baf)

**Package page after**

![package-after](https://github.com/wbond/packagecontrol.io/assets/44148/88fd90b5-4224-458e-9773-a1105edef2bc)