### PR TITLE
Fix #100 pre release versions not shown for some packages

### DIFF
--- a/app/templates/package.handlebars
+++ b/app/templates/package.handlebars
@@ -66,6 +66,13 @@
                 </span>
             {{else}}
                 <span>{{versions.[0].version}}</span>
+                {{#if versions.[0].prerelease_version}}
+                    <div>
+                        {{>version_qualifiers platforms=versions.[0].platforms}}
+                        <span class="versions only" title="Prerelease">PRE</span>
+                        {{versions.[0].prerelease_version}}
+                    </div>
+                {{/if}}
             {{/length}}
         </li>
         <li class="homepage">


### PR DESCRIPTION
When a package pre release version supports the same platforms then there is only one item in versions:

```
    'versions': [
        {
            'version': '1.29.1',
            'prerelease_version': '1.30.0-beta.2',
            'platforms': ['*'],
            'st_versions': ['3', '4']
        }
    ],
```

**Q. Do I need to include the app.css and app.js files?**

**Before**

![pre-before](https://github.com/wbond/packagecontrol.io/assets/44148/3e03776d-7e81-471e-8a44-04b88a299d64)

**After**

![pre-after](https://github.com/wbond/packagecontrol.io/assets/44148/29a51036-504a-4482-b390-e6162d026c32)
