### PR TITLE
Improve rate limit missing

### DIFF
--- a/app/lib/refresh_packages.py
+++ b/app/lib/refresh_packages.py
@@ -181,11 +181,14 @@ def refresh_packages(invalid_sources=None, invalid_dependency_sources=None):
                     dependency.mark_missing(source, clean_url(exception), needs_review(exception))
 
             for package_name, exception in provider.get_broken_packages():
-                package.modify.mark_missing_by_name(package_name, clean_url(exception), needs_review(exception))
+                # Don't mark a package as missing if we run out of requests
+                if not isinstance(exception, RateLimitException):
+                    package.modify.mark_missing_by_name(package_name, clean_url(exception), needs_review(exception))
 
             for dependency_name, exception in provider.get_broken_dependencies():
-                dependency.mark_missing_by_name(dependency_name, clean_url(exception), needs_review(exception))
-
+                # Don't mark a package as missing if we run out of requests
+                if not isinstance(exception, RateLimitException):
+                    dependency.mark_missing_by_name(dependency_name, clean_url(exception), needs_review(exception))
             break
 
     close_all_connections()

--- a/app/tasks/crawl.py
+++ b/app/tasks/crawl.py
@@ -34,8 +34,8 @@ if explicit_package:
     valid_sources = package.sources.sources_for(explicit_package)
     valid_dependency_sources = []
 else:
-    valid_sources = package.sources.outdated_sources(60, 200)
-    valid_dependency_sources = dependency.outdated_sources(60, 200)
+    valid_sources = package.sources.outdated_sources(240, 600)
+    valid_dependency_sources = dependency.outdated_sources(240, 600)
 
 invalid_sources = package.sources.invalid_sources(valid_sources)
 invalid_dependency_sources = dependency.invalid_sources(valid_dependency_sources)

--- a/app/tasks/crawl.py
+++ b/app/tasks/crawl.py
@@ -34,8 +34,8 @@ if explicit_package:
     valid_sources = package.sources.sources_for(explicit_package)
     valid_dependency_sources = []
 else:
-    valid_sources = package.sources.outdated_sources(240, 600)
-    valid_dependency_sources = dependency.outdated_sources(240, 600)
+    valid_sources = package.sources.outdated_sources(120, 600)
+    valid_dependency_sources = dependency.outdated_sources(120, 600)
 
 invalid_sources = package.sources.invalid_sources(valid_sources)
 invalid_dependency_sources = dependency.invalid_sources(valid_dependency_sources)


### PR DESCRIPTION
This PR builds on recent changes made by @wbond to fix some rate-limit related issues
and backports changes from four-point-oh branch targetting same sort of issues.

It also adds `RateLimitSkipException` exception, which is raised if a url is crawled after rate limit was hit. It may therefore also be associated with failed sources, packages or libraries.

Note packages and dependencies can be assigned those exceptions when rate limit is hit when downloading release information by following lines (packages):

https://github.com/wbond/packagecontrol.io/blob/9f5eb7e3392e6bc2ad979ad32d3dd27ef9c00b20/app/lib/package_control/providers/repository_provider.py#L818-L819