### PR TITLE
Mark removed packages automatically

### DIFF
--- a/crontab
+++ b/crontab
@@ -4,6 +4,7 @@ PACKAGE_CONTROL_ENV=prod
 */10 * * * *            /var/www/packagecontrol.io/venv/bin/python /var/www/packagecontrol.io/tasks.py generate_legacy_channel_json > /dev/null
 */5 * * * *             /var/www/packagecontrol.io/venv/bin/python /var/www/packagecontrol.io/tasks.py crawl > /dev/null
 */5 * * * *             /var/www/packagecontrol.io/venv/bin/python /var/www/packagecontrol.io/tasks.py cleanup_renames
+*/5 * * * *             /var/www/packagecontrol.io/venv/bin/python /var/www/packagecontrol.io/tasks.py mark_removed
 5 * * * *               /var/www/packagecontrol.io/venv/bin/python /var/www/packagecontrol.io/tasks.py refresh_package_stats
 2 0 * * *               /var/www/packagecontrol.io/venv/bin/python /var/www/packagecontrol.io/tasks.py parse_log_files > /dev/null
 2 0 * * *               /var/www/packagecontrol.io/venv/bin/python /var/www/packagecontrol.io/tasks.py gather_system_stats > /dev/null


### PR DESCRIPTION
This commit fixes `mark_removed` task, by really marking only those packages as removed in database, which don't have any valid download source anymore and are not already marked `missing` - possibly due to networking issues.

Run cleanup regularly via cron, like rename cleanups.

The goal is to stop delivering packages to clients, which have been removed from `package_control_channel` as associated URLs/repos might be taken over by bad actors delivering malware.