### PR TITLE
Fix folder name in submitting_a_package.html

### DIFF
--- a/app/html/docs/submitting_a_package.html
+++ b/app/html/docs/submitting_a_package.html
@@ -168,7 +168,7 @@
 		<b>Clone your fork to your machine</b>
 	</li>
 	<li>
-		<b>Open the <tt>package_control_channel/</tt> folder with Sublime Text</b>
+		<b>Go to the <tt>repository/</tt> folder and open the appropiate file based on the first letter of your package name (e.g. edit <tt>a.json</tt>tt> if your package name starts with letter <tt>a</tt> )</b>
 	</li>
 	<li>
 		<p>


### PR DESCRIPTION
It mentions a `package_control_channel/` folder which no longer exists, it is now the `repository` folder.

Add more info about the correct file to edit in that folder.